### PR TITLE
Use `pull_request_target` trigger

### DIFF
--- a/.github/workflows/cleanup-pr.yml
+++ b/.github/workflows/cleanup-pr.yml
@@ -2,7 +2,7 @@ name: Cleanup Pull Request
 
 on:
   # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
-  pull_request:
+  pull_request_target:
     types: [ closed ]
 
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -3,7 +3,7 @@ on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
     branches: [ main ]
-  pull_request:
+  pull_request_target:
     branches: [ main ]
 jobs:
   Explore-GitHub-Actions:
@@ -28,5 +28,5 @@ jobs:
       # - name: List files in the repository
       #   run: |
       #     ls ${{ github.workspace }}
-      - run: bash -lc 'mamba --version'
+      - run: mamba --version
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
     branches: [ main ]
-  pull_request:
+  pull_request_target:
     branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# Repository for the `mambaforge` Container Image
+# The `mambaforge` Container Image
 


### PR DESCRIPTION
Allows PRs from public forks to still use secrets:
https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks