### PR TITLE
Don't use `GITHUB_TOKEN` to push to GHCR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
           image_tag="latest"
           buildah tag localhost/mambaforge "${image_name}:${image_tag}"
           buildah images
-          buildah login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} ghcr.io
+          buildah login --username ${{ github.actor }} --password ${{ secrets.GHCR_TOKEN }} ghcr.io
           # https://github.community/t/package-container-linking-via-label-not-working/176401/12
           buildah push --format v2s2 "${image_name}:${image_tag}"
 


### PR DESCRIPTION
The GitHub token prevents subsequent actions from being triggered e.g. the [`registry_package`](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#registry_package) event.

----

<a href="https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token">
 <img src="https://user-images.githubusercontent.com/881019/148006982-c6aa12be-9c8a-4743-96d1-8ff74cfff068.png" >
</a>