### PR TITLE
Escape the `.github` repo name

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   delete-untagged-images:
-    uses: energy-quants/.github/workflows/cleanup-images.yml@main
+    uses: energy-quants/%2Egithub/workflows/cleanup-images.yml@main
     with:
       org: energy-quants
       repo: mambaforge


### PR DESCRIPTION
Workaround parsing bug in GitHub Actions